### PR TITLE
can't get v:count

### DIFF
--- a/autoload/operator/user.vim
+++ b/autoload/operator/user.vim
@@ -92,6 +92,7 @@ endfunction
 
 function! operator#user#_set_up(operator_function_name)
   let &operatorfunc = a:operator_function_name
+  let s:count_designation = v:count
   let s:register_designation = v:register
 endfunction
 
@@ -121,13 +122,16 @@ endfunction
 
 
 
+function! s:count_designation()
+  return s:count_designation ? s:count_designation : ''
+endfunction
 
 " count  "{{{2
 " BUGS: The original definition is as follows but it rarely doesn't work,
 "       because v:count1 may be 0 in some cases.  It is a bug of Vim.
 "
 "       nnoremap <expr> <SID>(count)  v:count == v:count1 ? v:count : ''
-nnoremap <expr> <SID>(count)  v:count ? v:count : ''
+nnoremap <expr> <SID>(count)  <SID>count_designation()
 
 " FIXME: It's hard for user-defined operator to handle count in Visual mode.
 " vnoremap <expr> <SID>(count)  v:count ? v:count : ''


### PR DESCRIPTION
今の動作は、 operator に渡した v:count が渡って来ずに、textobj に渡した数値が渡ってきていて、
ヘルプにある `10__` なども正しく動作していません。

`<SID>(register)` のように `<SID>(count)` を定義すると意図した動作になりました。
