### PR TITLE
Ignore doc/tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vim-flavor
 Gemfile.lock
 VimFlavor.lock
+doc/tags


### PR DESCRIPTION
Vim's generated tag files should be ignored (especially convenient when pulling the repo in as a submodule of a dotfiles/bundle repo).